### PR TITLE
Ignore vim swap files in current and subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .Trashes
 
 # c.f. http://www.westwind.com/reference/os-x/invisibles.html
-*.swp
+**.sw[a-z]
 
 #####
 # Node stuff


### PR DESCRIPTION
Before this repo had a rule to ignore vim swap files only in content
folder (./) but not in subdirectories. When you use vim swap files are
created throughout the project next to edited files